### PR TITLE
build: add binder config

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,13 @@
+# Ref: https://mybinder.readthedocs.io/en/latest/using/config_files.html#configuration-files
+# 2023-12-19: Python 3.12 is not supported at the moment
+#
+# installs the latest version of these dependencies
+dependencies:
+  - python=3.11
+  - matplotlib
+  - pandas
+  - nltk
+  - scattertext
+  - scikit-learn
+  - spacy
+  - spacy-transformers

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# update pip
+python -m pip install --upgrade pip
+
+# display installed versions
+python -V
+python -m pip list
+
+# install NLTL Punkt tokenizer
+python -m nltk.downloader punkt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # dracor-notebooks
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/dracor-org/dracor-notebooks/main)
+
 A collection of notebooks to showcase the work with data extracted from [DraCor corpora](https://dracor.org) and in particular the [DraCor API](https://dracor.org/doc/api):
 
 * [API Tutorial](https://github.com/dracor-org/dracor-notebooks/tree/main/api-tutorial) (in progress)


### PR DESCRIPTION
Q: Install spacy model in binder postbuild?

```
python -m spacy download de_dep_news_trf
# or
python -m spacy download de_core_news_sm
```

Increases build time and docker image size.

Q: Add version constraints to installable packages? This was not done in the original notebooks either, so I guess "latest" version is fine?

## Tasks

- [x] test python 3.12 -> does not work
- [x] remove spacy model download line
- [x] add comment about latest versions
- [x] add "launch binder" link
- [x] rebase branch
- [x] squash commits
